### PR TITLE
Simple Dockerfile has been added with minor gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ target/
 .project
 .settings/
 .classpath
-
+.idea
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:20.04
+
+LABEL name="kih-anvendelse" \
+    description="KIH Anvendelse" \
+    maintainer="Kvalitets IT"
+
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y locales \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales \
+    && update-locale LANG=en_US.UTF-8
+
+RUN apt update
+RUN apt-get install -y openjdk-8-jdk
+RUN apt-get install -y maven git-all
+
+RUN mkdir /kih-anvendelse
+# Copy source code here
+COPY . /kih-anvendelse
+
+CMD ["bash"]
+# Use this file with docker
+# >>> docker build -t kih-anvendelse .
+# >>> docker run -it kih-anvendelse
+# >>> cd /kih-anvendelse
+# >>> mvn clean install
+


### PR DESCRIPTION
Hi,
Regarding issue https://github.com/KvalitetsIT/kih-anvendelse/issues/1, I come to understand that exact OpenJDK 8 is required  and which is not available for MacOS  (some licenses issue).
Based on @leneandersen's input I have created a simple Dockerfile which will allow developers to see the impact of local changes by building docker image locally (will not require git clone)